### PR TITLE
Add CI, tests project, and DataRepository fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore LikesAndSwipes.slnx
+
+      - name: Build
+        run: dotnet build LikesAndSwipes.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test LikesAndSwipes.slnx --configuration Release --no-build

--- a/LikesAndSwipes.Tests/DataRepositoryTests.cs
+++ b/LikesAndSwipes.Tests/DataRepositoryTests.cs
@@ -1,0 +1,34 @@
+using LikesAndSwipes.Data;
+using LikesAndSwipes.Models;
+using LikesAndSwipes.Repositories;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace LikesAndSwipes.Tests;
+
+public class DataRepositoryTests
+{
+    [Fact]
+    public async Task SaveUserFirstName_Throws_WhenUserDoesNotExist()
+    {
+        using var connection = new SqliteConnection("DataSource=:memory:");
+        await connection.OpenAsync();
+
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+        await using var context = new ApplicationDbContext(options);
+        await context.Database.EnsureCreatedAsync();
+
+        var repository = new DataRepository(context);
+
+        var act = () => repository.SaveUserFirstName(new User
+        {
+            Id = "missing-user-id",
+            FirstName = "Alice"
+        });
+
+        await Assert.ThrowsAsync<InvalidOperationException>(act);
+    }
+}

--- a/LikesAndSwipes.Tests/LikesAndSwipes.Tests.csproj
+++ b/LikesAndSwipes.Tests/LikesAndSwipes.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\LikesAndSwipes\LikesAndSwipes.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LikesAndSwipes.slnx
+++ b/LikesAndSwipes.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="LikesAndSwipes/LikesAndSwipes.csproj" />
+  <Project Path="LikesAndSwipes.Tests/LikesAndSwipes.Tests.csproj" />
 </Solution>

--- a/LikesAndSwipes/Repositories/DataRepository.cs
+++ b/LikesAndSwipes/Repositories/DataRepository.cs
@@ -6,7 +6,7 @@ namespace LikesAndSwipes.Repositories
 {
     public class DataRepository
     {
-        private ApplicationDbContext _context;
+        private readonly ApplicationDbContext _context;
 
         public DataRepository(ApplicationDbContext context)
         {
@@ -16,21 +16,9 @@ namespace LikesAndSwipes.Repositories
         public async Task<LocationEntity> SaveUserLocation(LocationEntity location)
         {
             _context.Locations.Add(location);
+            await _context.SaveChangesAsync();
 
-            try
-            {
-                await _context.SaveChangesAsync();
-            }
-            catch (Exception ex)
-            {
-
-            }
-
-            long generatedId = location.Id;
-
-            //LocationEntity savedLocation = await _context.Locations.FirstAsync(x => x.Id == generatedId);
-
-            return location; // savedLocation;
+            return location;
         }
 
         public async Task<List<Interests>> GetAllInterests()
@@ -42,19 +30,29 @@ namespace LikesAndSwipes.Repositories
 
         public async Task SaveUserFirstName(User user)
         {
-            var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Id == user.Id);
+            var currentUser = await _context.Users.OfType<User>().FirstOrDefaultAsync(x => x.Id == user.Id);
 
-            ((User)currentUser).FirstName = user.FirstName;
+            if (currentUser is null)
+            {
+                throw new InvalidOperationException($"User with id '{user.Id}' was not found.");
+            }
+
+            currentUser.FirstName = user.FirstName;
 
             await _context.SaveChangesAsync();
         }
 
         public async Task SaveUserRegistrationData(User user)
         {
-            var currentUser = await _context.Users.FirstOrDefaultAsync(x => x.Id == user.Id);
+            var currentUser = await _context.Users.OfType<User>().FirstOrDefaultAsync(x => x.Id == user.Id);
 
-            ((User)currentUser).FirstName = user.FirstName;
-            ((User)currentUser).Age = user.Age;
+            if (currentUser is null)
+            {
+                throw new InvalidOperationException($"User with id '{user.Id}' was not found.");
+            }
+
+            currentUser.FirstName = user.FirstName;
+            currentUser.Age = user.Age;
             currentUser.UserName = user.FirstName;
 
             await _context.SaveChangesAsync();


### PR DESCRIPTION
### Motivation
- Introduce automated CI and a unit test project to catch data-layer regressions and tighten error handling in the repository methods.

### Description
- Add GitHub Actions workflow `ci.yml` to restore, build, and run `dotnet test LikesAndSwipes.slnx` on `ubuntu-latest` for pushes and pull requests.
- Add a new test project `LikesAndSwipes.Tests` and include it in the solution via `LikesAndSwipes.slnx`.
- Add `DataRepositoryTests.SaveUserFirstName_Throws_WhenUserDoesNotExist` which uses an in-memory SQLite connection to validate missing-user behavior.
- Update `DataRepository` to make `_context` readonly, call `SaveChangesAsync` in `SaveUserLocation`, use `OfType<User>()` and throw `InvalidOperationException` when a user is not found, and simplify property assignments.

### Testing
- Added an xUnit test `DataRepositoryTests.SaveUserFirstName_Throws_WhenUserDoesNotExist` as part of the new `LikesAndSwipes.Tests` project.
- The new CI workflow is configured to run `dotnet restore`, `dotnet build`, and `dotnet test LikesAndSwipes.slnx`; no automated test run results are included in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1492ab7a8832d8088d23dfb2a8ce3)