### PR TITLE
Implement interactive swipe-based UI on Match page

### DIFF
--- a/LikesAndSwipes/Views/Match/Index.cshtml
+++ b/LikesAndSwipes/Views/Match/Index.cshtml
@@ -1,6 +1,387 @@
-﻿@{
-    ViewData["Title"] = "Match page";
+@{
+    ViewData["Title"] = "Match";
 }
-<h1>@ViewData["Title"]</h1>
 
-<p>Match page</p>
+<div class="fd-page">
+    <header class="fd-header">
+        <button class="fd-header-btn" type="button" onclick="alert('Profile settings coming soon!')" aria-label="Profile settings">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
+                <circle cx="12" cy="7" r="4"></circle>
+            </svg>
+        </button>
+
+        <div class="fd-logo">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10 10-4.5 10-10S17.5 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"></path>
+            </svg>
+            <h1>FlameDate</h1>
+        </div>
+
+        <button class="fd-header-btn" type="button" onclick="alert('Messages feature coming soon!')" aria-label="Messages">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+            </svg>
+            <span class="fd-notification-dot"></span>
+        </button>
+    </header>
+
+    <main class="fd-main-container">
+        <div id="cardStack" class="fd-card-stack"></div>
+        <div id="noProfiles" class="fd-no-profiles" hidden>
+            <h2>No More Profiles</h2>
+            <p>Check back later for more matches!</p>
+            <button class="fd-restart-btn" type="button" onclick="app.restart()">Start Over</button>
+        </div>
+
+        <div class="fd-action-buttons">
+            <button class="fd-action-btn small undo" type="button" onclick="app.undo()" id="undoBtn" disabled>
+                <svg width="20" height="20" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M3 7v6h6"></path>
+                    <path d="M21 17a9 9 0 00-9-9 9 9 0 00-6 2.3L3 13"></path>
+                </svg>
+            </button>
+
+            <button class="fd-action-btn nope" type="button" onclick="app.swipe('left')">
+                <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true">
+                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                </svg>
+            </button>
+
+            <button class="fd-action-btn medium super-like" type="button" onclick="app.superLike()">
+                <svg width="24" height="24" viewBox="0 0 24 24" aria-hidden="true">
+                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+                </svg>
+            </button>
+
+            <button class="fd-action-btn like" type="button" onclick="app.swipe('right')">
+                <svg width="32" height="32" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+                </svg>
+            </button>
+        </div>
+    </main>
+
+    <div id="matchModal" class="fd-match-modal" onclick="app.closeMatch(event)">
+        <div class="fd-hearts-container" id="heartsContainer"></div>
+        <div class="fd-match-content" onclick="event.stopPropagation()">
+            <svg class="fd-match-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>
+            </svg>
+
+            <h2 class="fd-match-title">It's a Match!</h2>
+            <p class="fd-match-text" id="matchText"></p>
+
+            <div class="fd-match-profile">
+                <img id="matchImage" src="" alt="Matched profile">
+                <div class="fd-match-profile-info">
+                    <div class="fd-match-profile-name" id="matchName"></div>
+                    <div class="fd-match-profile-location" id="matchLocation"></div>
+                </div>
+            </div>
+
+            <div class="fd-match-buttons">
+                <button class="fd-match-btn secondary" type="button" onclick="app.closeMatch()">Keep Swiping</button>
+                <button class="fd-match-btn primary" type="button" onclick="app.sendMessage()">
+                    <svg viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+                    </svg>
+                    Send Message
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+    .fd-page, .fd-page * { box-sizing: border-box; }
+    .fd-page {
+        margin: -24px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        background: linear-gradient(135deg, #fce4ec 0%, #f3e5f5 50%, #e3f2fd 100%);
+        min-height: calc(100vh - 56px);
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+    }
+    .fd-header { display:flex; align-items:center; justify-content:space-between; padding:1rem 1.5rem; background:white; box-shadow:0 2px 8px rgba(0,0,0,0.1); z-index:100; }
+    .fd-header-btn { width:40px; height:40px; border:none; background:transparent; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; transition:background .2s; position:relative; }
+    .fd-header-btn:hover { background:#f5f5f5; }
+    .fd-header-btn svg { width:24px; height:24px; stroke:#666; fill:none; stroke-width:2; }
+    .fd-notification-dot { position:absolute; top:8px; right:8px; width:8px; height:8px; background:#ef4444; border-radius:50%; }
+    .fd-logo { display:flex; align-items:center; gap:.5rem; }
+    .fd-logo svg { width:32px; height:32px; fill:#ef4444; }
+    .fd-logo h1 { font-size:1.5rem; margin:0; background:linear-gradient(135deg,#ef4444,#ec4899); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text; }
+    .fd-main-container { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; padding:2rem 1rem; position:relative; }
+    .fd-card-stack { position:relative; width:100%; max-width:400px; aspect-ratio:3/4; margin-bottom:2rem; }
+    .fd-card { position:absolute; width:100%; height:100%; background:white; border-radius:1rem; box-shadow:0 10px 40px rgba(0,0,0,.15); overflow:hidden; cursor:grab; transition:transform .3s ease, opacity .3s ease; user-select:none; }
+    .fd-card.dragging { cursor:grabbing; transition:none; }
+    .fd-card.swiped-right { animation:fdSwipeRight .5s ease-out forwards; }
+    .fd-card.swiped-left { animation:fdSwipeLeft .5s ease-out forwards; }
+    @@keyframes fdSwipeRight { to { transform:translateX(150%) rotate(25deg); opacity:0; } }
+    @@keyframes fdSwipeLeft { to { transform:translateX(-150%) rotate(-25deg); opacity:0; } }
+    .fd-card-image { width:100%; height:100%; object-fit:cover; }
+    .fd-card-gradient { position:absolute; bottom:0; left:0; right:0; height:60%; background:linear-gradient(to top, rgba(0,0,0,.7), rgba(0,0,0,.2) 60%, transparent); pointer-events:none; }
+    .fd-swipe-indicator { position:absolute; top:2rem; padding:.75rem 1.5rem; border:4px solid; border-radius:.5rem; font-size:2rem; font-weight:700; opacity:0; transition:opacity .2s; pointer-events:none; }
+    .fd-like-indicator { left:2rem; color:#22c55e; border-color:#22c55e; transform:rotate(-20deg); }
+    .fd-nope-indicator { right:2rem; color:#ef4444; border-color:#ef4444; transform:rotate(20deg); }
+    .fd-card.show-like .fd-like-indicator, .fd-card.show-nope .fd-nope-indicator { opacity:1; }
+    .fd-profile-info { position:absolute; bottom:0; left:0; right:0; padding:1.5rem; color:white; z-index:10; }
+    .fd-profile-header { display:flex; justify-content:space-between; align-items:flex-end; margin-bottom:.5rem; gap:1rem; }
+    .fd-profile-name { font-size:1.75rem; font-weight:700; margin-bottom:.5rem; }
+    .fd-info-btn { width:48px; height:48px; background:rgba(255,255,255,.2); backdrop-filter:blur(10px); border:none; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; transition:background .2s; flex-shrink:0; }
+    .fd-info-btn:hover { background:rgba(255,255,255,.3); }
+    .fd-info-btn svg { width:24px; height:24px; stroke:white; fill:none; stroke-width:2; }
+    .fd-profile-detail { display:flex; align-items:center; gap:.5rem; font-size:.875rem; margin-bottom:.25rem; }
+    .fd-profile-detail svg { width:16px; height:16px; stroke:white; fill:none; stroke-width:2; }
+    .fd-profile-bio { margin-top:1rem; font-size:.875rem; line-height:1.5; max-height:0; overflow:hidden; transition:max-height .3s ease; }
+    .fd-profile-bio.show { max-height:200px; }
+    .fd-interests { display:flex; flex-wrap:wrap; gap:.5rem; margin-top:.75rem; }
+    .fd-interest-tag { padding:.25rem .75rem; background:rgba(255,255,255,.2); backdrop-filter:blur(10px); border-radius:1rem; font-size:.75rem; }
+    .fd-action-buttons { display:flex; align-items:center; justify-content:center; gap:1rem; }
+    .fd-action-btn { width:64px; height:64px; background:white; border:none; border-radius:50%; box-shadow:0 4px 12px rgba(0,0,0,.15); cursor:pointer; display:flex; align-items:center; justify-content:center; transition:transform .2s, box-shadow .2s; }
+    .fd-action-btn:hover { transform:scale(1.1); box-shadow:0 6px 20px rgba(0,0,0,.2); }
+    .fd-action-btn:active { transform:scale(.95); }
+    .fd-action-btn:disabled { opacity:.3; cursor:not-allowed; }
+    .fd-action-btn:disabled:hover { transform:scale(1); }
+    .fd-action-btn.small { width:48px; height:48px; }
+    .fd-action-btn.medium { width:56px; height:56px; }
+    .fd-action-btn svg { stroke-width:2; fill:none; }
+    .fd-action-btn.nope svg { stroke:#ef4444; }
+    .fd-action-btn.like svg { stroke:#22c55e; fill:#22c55e; }
+    .fd-action-btn.super-like svg { stroke:#3b82f6; fill:#3b82f6; }
+    .fd-action-btn.undo svg { stroke:#eab308; }
+    .fd-match-modal { position:fixed; inset:0; background:rgba(0,0,0,.8); backdrop-filter:blur(10px); display:none; align-items:center; justify-content:center; z-index:1000; animation:fdFadeIn .3s ease; }
+    .fd-match-modal.show { display:flex; }
+    @@keyframes fdFadeIn { from { opacity:0; } to { opacity:1; } }
+    .fd-match-content { background:white; border-radius:1.5rem; padding:2rem; max-width:400px; width:90%; text-align:center; position:relative; animation:fdScaleIn .5s cubic-bezier(0.34, 1.56, 0.64, 1); }
+    @@keyframes fdScaleIn { from { transform:scale(.5); opacity:0; } to { transform:scale(1); opacity:1; } }
+    .fd-hearts-container { position:absolute; inset:0; pointer-events:none; overflow:hidden; }
+    .fd-floating-heart { position:absolute; left:50%; bottom:50%; width:32px; height:32px; animation:fdFloatHeart 2s ease-out infinite; }
+    @@keyframes fdFloatHeart { 0% { transform:translate(-50%, 0) scale(0); opacity:1; } 50% { opacity:1; } 100% { transform:translate(var(--tx), -200px) scale(0); opacity:0; } }
+    .fd-match-icon { width:80px; height:80px; margin:0 auto 1rem; fill:#ec4899; animation:fdHeartBeat 1s ease infinite; }
+    @@keyframes fdHeartBeat { 0%,100% { transform:scale(1); } 50% { transform:scale(1.1); } }
+    .fd-match-title { font-size:2.5rem; font-weight:700; background:linear-gradient(135deg,#ec4899,#ef4444); -webkit-background-clip:text; -webkit-text-fill-color:transparent; background-clip:text; margin-bottom:1rem; }
+    .fd-match-text { color:#666; margin-bottom:1.5rem; }
+    .fd-match-profile { position:relative; height:200px; border-radius:1rem; overflow:hidden; margin-bottom:1.5rem; }
+    .fd-match-profile img { width:100%; height:100%; object-fit:cover; }
+    .fd-match-profile-info { position:absolute; bottom:1rem; left:1rem; color:white; text-align:left; text-shadow:0 1px 3px rgba(0,0,0,.6); }
+    .fd-match-profile-name { font-size:1.5rem; font-weight:700; }
+    .fd-match-profile-location { font-size:.875rem; }
+    .fd-match-buttons { display:flex; gap:.75rem; }
+    .fd-match-btn { flex:1; padding:.875rem 1.5rem; border:none; border-radius:2rem; font-size:1rem; font-weight:600; cursor:pointer; transition:all .2s; display:flex; align-items:center; justify-content:center; gap:.5rem; }
+    .fd-match-btn.secondary { border:2px solid #ddd; background:white; color:#333; }
+    .fd-match-btn.secondary:hover { background:#f5f5f5; }
+    .fd-match-btn.primary { background:linear-gradient(135deg,#ec4899,#ef4444); color:white; }
+    .fd-match-btn.primary:hover { background:linear-gradient(135deg,#db2777,#dc2626); }
+    .fd-match-btn svg { width:20px; height:20px; stroke:currentColor; fill:none; stroke-width:2; }
+    .fd-no-profiles { text-align:center; }
+    .fd-no-profiles h2 { font-size:2rem; color:#333; margin-bottom:1rem; }
+    .fd-no-profiles p { color:#666; margin-bottom:1.5rem; }
+    .fd-restart-btn { padding:.875rem 2rem; background:linear-gradient(135deg,#ec4899,#ef4444); color:white; border:none; border-radius:2rem; font-size:1rem; font-weight:600; cursor:pointer; transition:all .2s; }
+    .fd-restart-btn:hover { background:linear-gradient(135deg,#db2777,#dc2626); }
+    @@media (max-width: 640px) {
+        .fd-page { margin:-24px -12px; }
+        .fd-card-stack { max-width:100%; }
+        .fd-action-btn { width:56px; height:56px; }
+        .fd-action-btn.small { width:44px; height:44px; }
+    }
+</style>
+
+@section Scripts {
+    <script>
+        const profiles = [
+            { id: 1, name: 'Sarah', age: 28, location: 'New York, NY', occupation: 'Marketing Manager', bio: 'Love exploring new cafes and hiking trails. Looking for someone who enjoys spontaneous adventures and good conversations over coffee.', image: 'https://images.unsplash.com/photo-1649589244330-09ca58e4fa64?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMHBvcnRyYWl0JTIwcHJvZmVzc2lvbmFsfGVufDF8fHx8MTc3MzQ5NDI0N3ww&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Coffee', 'Hiking', 'Photography', 'Travel'] },
+            { id: 2, name: 'Michael', age: 32, location: 'Los Angeles, CA', occupation: 'Software Engineer', bio: 'Tech enthusiast and weekend chef. I code by day and cook gourmet meals by night. Looking for my sous chef in life!', image: 'https://images.unsplash.com/photo-1554765345-6ad6a5417cde?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtYW4lMjBwb3J0cmFpdCUyMHByb2Zlc3Npb25hbHxlbnwxfHx8fDE3NzM0NzM1MjB8MA&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Cooking', 'Gaming', 'Fitness', 'Tech'] },
+            { id: 3, name: 'Emily', age: 26, location: 'Chicago, IL', occupation: 'Graphic Designer', bio: "Creative soul with a passion for art and music. Spend my weekends at concerts or sketching in the park. Let's create something beautiful together!", image: 'https://images.unsplash.com/photo-1561648512-2d9c26a7768b?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx5b3VuZyUyMHdvbWFuJTIwc21pbGUlMjBvdXRkb29yfGVufDF8fHx8MTc3MzUwMTU0OXww&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Art', 'Music', 'Design', 'Concerts'] },
+            { id: 4, name: 'James', age: 30, location: 'San Francisco, CA', occupation: 'Photographer', bio: 'Capturing moments and chasing sunsets. Adventure seeker who loves road trips and finding hidden gems. Ready to explore the world with someone special.', image: 'https://images.unsplash.com/photo-1695485121912-25c7ea05119c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxtYW4lMjBjYXN1YWwlMjBwb3J0cmFpdHxlbnwxfHx8fDE3NzM0NzczNTh8MA&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Photography', 'Travel', 'Nature', 'Road Trips'] },
+            { id: 5, name: 'Isabella', age: 29, location: 'Miami, FL', occupation: 'Yoga Instructor', bio: 'Beach lover and wellness enthusiast. Finding balance through yoga, meditation, and ocean swims. Looking for positive vibes and authentic connections.', image: 'https://images.unsplash.com/photo-1650895422057-355060e05c95?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx3b21hbiUyMGJlYWNoJTIwcG9ydHJhaXR8ZW58MXx8fHwxNzczNTAxNTUwfDA&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Yoga', 'Wellness', 'Beach', 'Meditation'] },
+            { id: 6, name: 'Daniel', age: 27, location: 'Austin, TX', occupation: 'Musician', bio: "Music is my life! From acoustic sessions to live performances, I live for the rhythm. Let's create our own soundtrack together.", image: 'https://images.unsplash.com/photo-1523287409476-a9e70a25af3f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHx5b3VuZyUyMG1hbiUyMG91dGRvb3J8ZW58MXx8fHwxNzczMzg4Nzc1fDA&ixlib=rb-4.1.0&q=80&w=1080', interests: ['Music', 'Guitar', 'Live Shows', 'Songwriting'] }
+        ];
+
+        class DatingApp {
+            constructor() {
+                this.profiles = [...profiles];
+                this.currentIndex = 0;
+                this.swipeHistory = [];
+                this.currentCard = null;
+                this.startX = 0;
+                this.isDragging = false;
+                this.matchProfile = null;
+                this.handleDrag = this.handleDrag.bind(this);
+                this.handleDragEnd = this.handleDragEnd.bind(this);
+                this.init();
+            }
+
+            init() { this.renderCards(); this.createFloatingHearts(); }
+
+            renderCards() {
+                const cardStack = document.getElementById('cardStack');
+                cardStack.innerHTML = '';
+                const visibleCount = Math.min(3, this.profiles.length - this.currentIndex);
+                if (visibleCount === 0) {
+                    cardStack.style.display = 'none';
+                    document.getElementById('noProfiles').hidden = false;
+                    return;
+                }
+                for (let i = visibleCount - 1; i >= 0; i--) {
+                    const profile = this.profiles[this.currentIndex + i];
+                    cardStack.appendChild(this.createCard(profile, i));
+                }
+                this.currentCard = cardStack.lastElementChild;
+                this.setupDragListeners(this.currentCard);
+            }
+
+            createCard(profile, stackIndex) {
+                const card = document.createElement('div');
+                card.className = 'fd-card';
+                card.style.zIndex = 3 - stackIndex;
+                card.style.transform = `scale(${1 - stackIndex * 0.05})`;
+                card.innerHTML = `
+                    <img src="${profile.image}" alt="${profile.name}" class="fd-card-image">
+                    <div class="fd-card-gradient"></div>
+                    <div class="fd-swipe-indicator fd-like-indicator">LIKE</div>
+                    <div class="fd-swipe-indicator fd-nope-indicator">NOPE</div>
+                    <div class="fd-profile-info">
+                        <div class="fd-profile-header">
+                            <div>
+                                <div class="fd-profile-name">${profile.name}, ${profile.age}</div>
+                                <div class="fd-profile-detail"><svg viewBox="0 0 24 24"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path><circle cx="12" cy="10" r="3"></circle></svg>${profile.location}</div>
+                                <div class="fd-profile-detail"><svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"></rect><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"></path></svg>${profile.occupation}</div>
+                                <div class="fd-profile-bio" id="bio-${profile.id}">
+                                    <p>${profile.bio}</p>
+                                    <div class="fd-interests">${profile.interests.map(i => `<span class="fd-interest-tag">${i}</span>`).join('')}</div>
+                                </div>
+                            </div>
+                            <button class="fd-info-btn" type="button" onclick="app.toggleInfo(${profile.id})"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="16" x2="12" y2="12"></line><line x1="12" y1="8" x2="12.01" y2="8"></line></svg></button>
+                        </div>
+                    </div>`;
+                return card;
+            }
+
+            setupDragListeners(card) {
+                card.addEventListener('mousedown', this.handleDragStart.bind(this));
+                card.addEventListener('touchstart', this.handleDragStart.bind(this), { passive: true });
+                document.addEventListener('mousemove', this.handleDrag);
+                document.addEventListener('touchmove', this.handleDrag, { passive: false });
+                document.addEventListener('mouseup', this.handleDragEnd);
+                document.addEventListener('touchend', this.handleDragEnd);
+            }
+
+            handleDragStart(e) {
+                if (e.target.closest('.fd-info-btn')) return;
+                this.isDragging = true;
+                this.currentCard.classList.add('dragging');
+                this.startX = e.type === 'mousedown' ? e.clientX : e.touches[0].clientX;
+            }
+
+            handleDrag(e) {
+                if (!this.isDragging || !this.currentCard) return;
+                if (e.cancelable) e.preventDefault();
+                const clientX = e.type === 'mousemove' ? e.clientX : e.touches[0].clientX;
+                const deltaX = clientX - this.startX;
+                this.currentCard.style.transform = `translateX(${deltaX}px) rotate(${deltaX / 20}deg)`;
+                if (deltaX > 50) {
+                    this.currentCard.classList.add('show-like');
+                    this.currentCard.classList.remove('show-nope');
+                } else if (deltaX < -50) {
+                    this.currentCard.classList.add('show-nope');
+                    this.currentCard.classList.remove('show-like');
+                } else {
+                    this.currentCard.classList.remove('show-like', 'show-nope');
+                }
+            }
+
+            handleDragEnd(e) {
+                if (!this.isDragging || !this.currentCard) return;
+                this.isDragging = false;
+                this.currentCard.classList.remove('dragging', 'show-like', 'show-nope');
+                const clientX = e.type === 'mouseup' ? e.clientX : e.changedTouches[0].clientX;
+                const deltaX = clientX - this.startX;
+                if (Math.abs(deltaX) > 100) {
+                    this.performSwipe(deltaX > 0 ? 'right' : 'left');
+                } else {
+                    this.currentCard.style.transform = '';
+                }
+            }
+
+            swipe(direction) { this.performSwipe(direction); }
+
+            performSwipe(direction) {
+                if (!this.currentCard || this.currentIndex >= this.profiles.length) return;
+                const profile = this.profiles[this.currentIndex];
+                this.currentCard.classList.add(direction === 'right' ? 'swiped-right' : 'swiped-left');
+                this.currentCard.style.transform = '';
+                this.swipeHistory.push(this.currentIndex);
+                document.getElementById('undoBtn').disabled = false;
+                if (direction === 'right' && Math.random() > 0.7) setTimeout(() => this.showMatch(profile), 500);
+                setTimeout(() => { this.currentIndex++; this.renderCards(); }, 500);
+            }
+
+            superLike() {
+                if (!this.currentCard || this.currentIndex >= this.profiles.length) return;
+                const profile = this.profiles[this.currentIndex];
+                this.swipeHistory.push(this.currentIndex);
+                document.getElementById('undoBtn').disabled = false;
+                if (Math.random() > 0.4) this.showMatch(profile);
+                this.currentCard.classList.add('swiped-right');
+                setTimeout(() => { this.currentIndex++; this.renderCards(); }, 500);
+            }
+
+            undo() {
+                if (!this.swipeHistory.length) return;
+                this.currentIndex = this.swipeHistory.pop();
+                document.getElementById('undoBtn').disabled = this.swipeHistory.length === 0;
+                this.renderCards();
+            }
+
+            toggleInfo(profileId) { document.getElementById(`bio-${profileId}`)?.classList.toggle('show'); }
+
+            showMatch(profile) {
+                this.matchProfile = profile;
+                document.getElementById('matchText').textContent = `You and ${profile.name} have liked each other`;
+                document.getElementById('matchImage').src = profile.image;
+                document.getElementById('matchName').textContent = `${profile.name}, ${profile.age}`;
+                document.getElementById('matchLocation').textContent = profile.location;
+                document.getElementById('matchModal').classList.add('show');
+            }
+
+            closeMatch(event) {
+                if (event && event.target.id !== 'matchModal') return;
+                document.getElementById('matchModal').classList.remove('show');
+                this.matchProfile = null;
+            }
+
+            sendMessage() {
+                if (!this.matchProfile) return;
+                alert(`Message sent to ${this.matchProfile.name}!`);
+                this.closeMatch();
+            }
+
+            restart() {
+                this.currentIndex = 0;
+                this.swipeHistory = [];
+                document.getElementById('undoBtn').disabled = true;
+                document.getElementById('noProfiles').hidden = true;
+                document.getElementById('cardStack').style.display = 'block';
+                this.renderCards();
+            }
+
+            createFloatingHearts() {
+                const container = document.getElementById('heartsContainer');
+                for (let i = 0; i < 6; i++) {
+                    const heart = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+                    heart.classList.add('fd-floating-heart');
+                    heart.setAttribute('viewBox', '0 0 24 24');
+                    heart.style.animationDelay = `${i * 0.2}s`;
+                    heart.style.setProperty('--tx', `${(Math.random() - 0.5) * 200}px`);
+                    heart.innerHTML = '<path fill="#ec4899" d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"></path>';
+                    container.appendChild(heart);
+                }
+            }
+        }
+
+        window.app = new DatingApp();
+    </script>
+}


### PR DESCRIPTION
### Motivation
- Replace the placeholder Match view with a rich, interactive swipe/match experience based on the provided HTML so users can swipe, super-like, undo, and see a match modal.
- Keep styles page-scoped to avoid global CSS collisions by prefixing classes with `fd-`.
- Provide a self-contained client-side implementation so the page can function without additional backend changes.

### Description
- Replaced the simple placeholder with full markup, scoped CSS, and client-side script in `Views/Match/Index.cshtml` to render the card stack, match modal, and action controls.
- Added a `profiles` data array and a `DatingApp` class that implements card rendering, drag/swipe gestures, `swipe`, `superLike`, `undo`, `restart`, `toggleInfo`, and match modal flows.
- Implemented UI affordances including like/nope indicators, animated swipe exit (`swiped-right`/`swiped-left`), floating heart animations, and an accessible `matchModal` with `Keep Swiping` and `Send Message` actions.
- Scoped all styles under `fd-` prefixes and added small accessibility improvements like `aria-hidden`, `aria-label` and using `hidden` attribute for the no-profiles state.

### Testing
- Attempted `dotnet build LikesAndSwipes.slnx` in this environment and it failed because the `dotnet` tool is not installed, so no build verification was performed.
- Attempted an automated browser check via Playwright to capture `http://127.0.0.1:5000/Match` and it failed with `ERR_EMPTY_RESPONSE` because the application server was not running in the environment.
- No other automated unit or integration tests were executed; the changes are limited to `Views/Match/Index.cshtml` and are ready for verification in a Dev environment with .NET and the app server running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5daf7fc9c832d9e6cf2a7876727be)