### PR TITLE
Add Google reCAPTCHA to registration step 8

### DIFF
--- a/LikesAndSwipes/Areas/Identity/Pages/Account/Register.cshtml
+++ b/LikesAndSwipes/Areas/Identity/Pages/Account/Register.cshtml
@@ -180,6 +180,7 @@
             <input type="text" asp-for="Input.Email" id="email" placeholder="Email or phone" style="font-size: 20px;" />
             <input type="password" asp-for="Input.Password" id="password" placeholder="Password" style="font-size: 20px;" />
             <input type="password" asp-for="Input.ConfirmPassword" id="confirmPassword" placeholder="Confirm password" style="font-size: 20px;" />
+            <div class="g-recaptcha" data-sitekey="@Model.RecaptchaSiteKey"></div>
             <div class="button-row">
                 <button type="button" class="btn-secondary back-btn">Back</button>
                 <button class="btn-primary" id="registerBtn" type="submit">Register</button>
@@ -195,5 +196,6 @@
             src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDXk-q6dHZSwnelPw7IxPOh-kuvobizqAM&libraries=places&callback=initAutocomplete" async defer>
     </script>
 
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
     <script src="~/js/addressautocomplit.js" asp-append-version="true"></script>
 }

--- a/LikesAndSwipes/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/LikesAndSwipes/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -12,10 +12,12 @@ using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Configuration;
 using NetTopologySuite.Geometries;
 using System.ComponentModel.DataAnnotations;
 using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 
 namespace LikesAndSwipes.Areas.Identity.Pages.Account
 {
@@ -28,6 +30,8 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
         private readonly ILogger<RegisterModel> _logger;
         private readonly IEmailSender _emailSender;
         private readonly IMinioStorageService _minioStorageService;
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IConfiguration _configuration;
         private DataRepository _dataRepository;
 
         public RegisterModel(
@@ -37,6 +41,8 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
             ILogger<RegisterModel> logger,
             IEmailSender emailSender,
             IMinioStorageService minioStorageService,
+            IHttpClientFactory httpClientFactory,
+            IConfiguration configuration,
             DataRepository dataRepository)
         {
             _userManager = userManager;
@@ -46,6 +52,8 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
             _logger = logger;
             _emailSender = emailSender;
             _minioStorageService = minioStorageService;
+            _httpClientFactory = httpClientFactory;
+            _configuration = configuration;
             _dataRepository = dataRepository;
         }
 
@@ -64,6 +72,8 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
 
         [BindProperty]
         public List<IFormFile> Photos { get; set; } = new();
+
+        public string RecaptchaSiteKey => _configuration["Recaptcha:SiteKey"] ?? string.Empty;
 
         /// <summary>
         ///     This API supports the ASP.NET Core Identity default UI infrastructure and is not intended to be used
@@ -175,6 +185,14 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
         {
             returnUrl ??= Url.Content("~/");
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
+
+            var recaptchaToken = Request.Form["g-recaptcha-response"].ToString();
+            var remoteIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+            if (!await ValidateRecaptchaAsync(recaptchaToken, remoteIp))
+            {
+                ModelState.AddModelError(string.Empty, "Please complete Google reCAPTCHA.");
+                return Page();
+            }
             if (ModelState.IsValid)
             {
                 var user = CreateUser();
@@ -320,6 +338,52 @@ namespace LikesAndSwipes.Areas.Identity.Pages.Account
 
                 throw;
             }
+        }
+
+
+        private async Task<bool> ValidateRecaptchaAsync(string token, string? remoteIp)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return false;
+            }
+
+            var recaptchaSecret = _configuration["Recaptcha:SecretKey"];
+            if (string.IsNullOrWhiteSpace(recaptchaSecret))
+            {
+                _logger.LogWarning("Recaptcha:SecretKey is not configured.");
+                return false;
+            }
+
+            var httpClient = _httpClientFactory.CreateClient();
+            var requestBody = new Dictionary<string, string>
+            {
+                ["secret"] = recaptchaSecret,
+                ["response"] = token
+            };
+
+            if (!string.IsNullOrWhiteSpace(remoteIp))
+            {
+                requestBody["remoteip"] = remoteIp;
+            }
+
+            using var content = new FormUrlEncodedContent(requestBody);
+            using var response = await httpClient.PostAsync("https://www.google.com/recaptcha/api/siteverify", content);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("reCAPTCHA verification failed with status code {StatusCode}", response.StatusCode);
+                return false;
+            }
+
+            var responseJson = await response.Content.ReadAsStringAsync();
+            var recaptchaResponse = JsonSerializer.Deserialize<RecaptchaVerifyResponse>(responseJson);
+
+            return recaptchaResponse?.Success ?? false;
+        }
+
+        private sealed class RecaptchaVerifyResponse
+        {
+            public bool Success { get; set; }
         }
 
         private IUserEmailStore<User> GetEmailStore()

--- a/LikesAndSwipes/Program.cs
+++ b/LikesAndSwipes/Program.cs
@@ -46,6 +46,7 @@ namespace LikesAndSwipes
             });
 
             builder.Services.AddControllersWithViews();
+            builder.Services.AddHttpClient();
             builder.Services.Configure<MinioOptions>(builder.Configuration.GetSection(MinioOptions.SectionName));
             builder.Services.AddSingleton<IMinioClient>(_ =>
             {

--- a/LikesAndSwipes/appsettings.json
+++ b/LikesAndSwipes/appsettings.json
@@ -16,6 +16,10 @@
     "UseSsl": false,
     "PresignedUrlExpirySeconds": 3600
   },
+  "Recaptcha": {
+    "SiteKey": "6Lcwu7IsAAAAAF-5CB8bXe2P37xn50m5cp5KwBZz",
+    "SecretKey": "6Lcwu7IsAAAAAF-5CB8bXe2P37xn50m5cp44wBZz"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/LikesAndSwipes/wwwroot/js/site.js
+++ b/LikesAndSwipes/wwwroot/js/site.js
@@ -240,22 +240,28 @@ function syncSelectedInterests() {
 }
 
 /* Registration validation */
-document.getElementById("registerBtn").addEventListener("click", () => {
+document.getElementById("registerBtn").addEventListener("click", event => {
     const email = document.getElementById("email").value.trim();
     const password = document.getElementById("password").value;
     const confirmPassword = document.getElementById("confirmPassword").value;
+    const recaptchaToken = document.querySelector('textarea[name="g-recaptcha-response"]')?.value?.trim();
 
     if (!email || !password || !confirmPassword) {
+        event.preventDefault();
         alert("Please fill all fields.");
         return;
     }
 
     if (password !== confirmPassword) {
+        event.preventDefault();
         alert("Passwords do not match.");
         return;
     }
 
-    //alert("Registration complete 🎉");
+    if (!recaptchaToken) {
+        event.preventDefault();
+        alert("Please complete Google reCAPTCHA.");
+    }
 });
 
 function initAddressAutocomplete() {


### PR DESCRIPTION
### Motivation
- Protect the final step of the multi-step registration flow from automated/bot signups by adding Google reCAPTCHA verification (site and secret keys provided). 
- Perform client-side blocking of form submission when reCAPTCHA is not completed to improve UX and reduce unnecessary server verification attempts.
- Perform server-side verification of the `g-recaptcha-response` token with Google `siteverify` before creating the user to ensure trusted protection.

### Description
- Added `Recaptcha` configuration with `SiteKey` and `SecretKey` to `appsettings.json` using the provided keys (`SiteKey` and `SecretKey`).
- Injected `IHttpClientFactory` and `IConfiguration` into `RegisterModel`, added a `RecaptchaSiteKey` property, and implemented `ValidateRecaptchaAsync` which posts to `https://www.google.com/recaptcha/api/siteverify` and parses the JSON response. 
- Added server-side check in `OnPostAsync` to read `Request.Form["g-recaptcha-response"]` and return the page with a model error when verification fails.
- Added the reCAPTCHA widget markup and loader script to `Register.cshtml` and added client-side validation in `wwwroot/js/site.js` to prevent submission when the `g-recaptcha-response` token is missing.
- Registered `AddHttpClient()` in `Program.cs` to enable server-side HTTP calls for verification.

### Testing
- Attempted to run `dotnet build LikesAndSwipes.sln`, which failed in this environment because `dotnet` is not available (`/bin/bash: line 1: dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac711f3e0832d90cdcaf6da5af8cd)