### PR TITLE
Add birth date editing in /user About Me section

### DIFF
--- a/LikesAndSwipes/Controllers/UserController.cs
+++ b/LikesAndSwipes/Controllers/UserController.cs
@@ -41,9 +41,11 @@ namespace LikesAndSwipes.Controllers
             }
 
             var photos = await _dataRepository.GetUserPhotos(userId);
+            var currentUser = await _userManager.GetUserAsync(User);
 
             var viewModel = new UserProfilePhotosViewModel
             {
+                BirthDay = currentUser?.BirthDay,
                 Photos = photos
             };
 
@@ -147,6 +149,38 @@ namespace LikesAndSwipes.Controllers
             {
                 _logger.LogError(ex, "Failed to delete profile photo {PhotoId} for user {UserId}", photoId, userId);
                 TempData["PhotoUploadError"] = "Не удалось удалить фотографию. Попробуйте позже.";
+            }
+
+            return RedirectToAction(nameof(GetUserPage));
+        }
+
+        [Authorize]
+        [ValidateAntiForgeryToken]
+        [HttpPost("user/birthday")]
+        public async Task<IActionResult> UpdateBirthDay(DateTime birthDay)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            if (birthDay == default || birthDay.Date > DateTime.UtcNow.Date || birthDay.Year < 1900)
+            {
+                TempData["BirthDayError"] = "Укажите корректную дату рождения.";
+                return RedirectToAction(nameof(GetUserPage));
+            }
+
+            user.BirthDay = DateTime.SpecifyKind(birthDay.Date, DateTimeKind.Utc);
+            var result = await _userManager.UpdateAsync(user);
+
+            if (result.Succeeded)
+            {
+                TempData["BirthDaySuccess"] = "Дата рождения обновлена.";
+            }
+            else
+            {
+                TempData["BirthDayError"] = "Не удалось обновить дату рождения. Попробуйте позже.";
             }
 
             return RedirectToAction(nameof(GetUserPage));

--- a/LikesAndSwipes/Models/UserProfilePhotosViewModel.cs
+++ b/LikesAndSwipes/Models/UserProfilePhotosViewModel.cs
@@ -4,6 +4,8 @@ namespace LikesAndSwipes.Models
     {
         public string UserName { get; set; } = string.Empty;
 
+        public DateTime? BirthDay { get; set; }
+
         public List<UserPhoto> Photos { get; set; } = new();
     }
 }

--- a/LikesAndSwipes/Views/User/GetUserPage.cshtml
+++ b/LikesAndSwipes/Views/User/GetUserPage.cshtml
@@ -6,8 +6,31 @@
 <section class="user-profile-page">
     <div class="user-profile-header">
         <h2>Обо мне:</h2>
-        
     </div>
+
+    <form asp-controller="User" asp-action="UpdateBirthDay" method="post" class="user-photo-upload-form">
+        @Html.AntiForgeryToken()
+        <label for="birthDay">Дата рождения</label>
+        <input id="birthDay"
+               type="date"
+               name="birthDay"
+               class="form-control user-photo-upload-input"
+               value="@(Model.BirthDay.HasValue ? Model.BirthDay.Value.ToString("yyyy-MM-dd") : string.Empty)"
+               max="@DateTime.UtcNow.ToString("yyyy-MM-dd")"
+               required />
+        <button type="submit" class="btn btn-primary" style="width: 220px; flex: none;">Сохранить дату рождения</button>
+    </form>
+
+    @if (TempData["BirthDaySuccess"] is string birthDaySuccessMessage)
+    {
+        <p class="user-photo-upload-success">@birthDaySuccessMessage</p>
+    }
+
+    @if (TempData["BirthDayError"] is string birthDayErrorMessage)
+    {
+        <p class="user-photo-upload-error">@birthDayErrorMessage</p>
+    }
+
     <div class="user-profile-header">
         <h2>Мои фотографии</h2>
         <a asp-area="Identity" asp-page="/Account/Manage/Index">Settings</a>


### PR DESCRIPTION
### Motivation
- Allow users to view and edit their birth date from the "Обо мне" section on the `/user` profile page.
- Persist the updated birth date on the user record with basic validation to prevent invalid dates.

### Description
- Added nullable `BirthDay` to the view model in `LikesAndSwipes/Models/UserProfilePhotosViewModel.cs` so the view can display the stored value.
- Updated `UserController.GetUserPage` to load the current user's `BirthDay` via `UserManager.GetUserAsync` and pass it into the view model.
- Implemented `POST /user/birthday` as `UpdateBirthDay(DateTime birthDay)` in `LikesAndSwipes/Controllers/UserController.cs` with validation (not default, not future, year >= 1900), converting the date to UTC via `DateTime.SpecifyKind` and saving via `_userManager.UpdateAsync` while providing success/error messages in `TempData`.
- Added a birthday edit form to `LikesAndSwipes/Views/User/GetUserPage.cshtml` (`<input type="date">`) and output for `TempData` messages to show success or error to the user.

### Testing
- Attempted to run `dotnet build LikesAndSwipes.slnx`, but the command failed in this environment with `/bin/bash: line 1: dotnet: command not found` so no build/test run was completed.
- No automated unit tests were executed in this session due to the missing `dotnet` runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec07583f74832db2e80c0ebc6d80ff)