### PR TITLE
Добавить редактирование предпочтений в разделе «Обо мне» на /user

### DIFF
--- a/LikesAndSwipes/Controllers/UserController.cs
+++ b/LikesAndSwipes/Controllers/UserController.cs
@@ -46,6 +46,10 @@ namespace LikesAndSwipes.Controllers
             var viewModel = new UserProfilePhotosViewModel
             {
                 BirthDay = currentUser?.BirthDay,
+                RomanticMen = currentUser?.RomanticMen ?? false,
+                RomanticWomen = currentUser?.RomanticWomen ?? false,
+                FriendshipMen = currentUser?.FriendshipMen ?? false,
+                FriendshipWomen = currentUser?.FriendshipWomen ?? false,
                 Photos = photos
             };
 
@@ -181,6 +185,42 @@ namespace LikesAndSwipes.Controllers
             else
             {
                 TempData["BirthDayError"] = "Не удалось обновить дату рождения. Попробуйте позже.";
+            }
+
+            return RedirectToAction(nameof(GetUserPage));
+        }
+
+        [Authorize]
+        [ValidateAntiForgeryToken]
+        [HttpPost("user/preferences")]
+        public async Task<IActionResult> UpdatePreferences(bool romanticMen, bool romanticWomen, bool friendshipMen, bool friendshipWomen)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user is null)
+            {
+                return Challenge();
+            }
+
+            if (!romanticMen && !romanticWomen && !friendshipMen && !friendshipWomen)
+            {
+                TempData["PreferenceError"] = "Выберите хотя бы одно предпочтение.";
+                return RedirectToAction(nameof(GetUserPage));
+            }
+
+            user.RomanticMen = romanticMen;
+            user.RomanticWomen = romanticWomen;
+            user.FriendshipMen = friendshipMen;
+            user.FriendshipWomen = friendshipWomen;
+
+            var result = await _userManager.UpdateAsync(user);
+
+            if (result.Succeeded)
+            {
+                TempData["PreferenceSuccess"] = "Предпочтения обновлены.";
+            }
+            else
+            {
+                TempData["PreferenceError"] = "Не удалось обновить предпочтения. Попробуйте позже.";
             }
 
             return RedirectToAction(nameof(GetUserPage));

--- a/LikesAndSwipes/Models/UserProfilePhotosViewModel.cs
+++ b/LikesAndSwipes/Models/UserProfilePhotosViewModel.cs
@@ -5,6 +5,10 @@ namespace LikesAndSwipes.Models
         public string UserName { get; set; } = string.Empty;
 
         public DateTime? BirthDay { get; set; }
+        public bool RomanticMen { get; set; }
+        public bool RomanticWomen { get; set; }
+        public bool FriendshipMen { get; set; }
+        public bool FriendshipWomen { get; set; }
 
         public List<UserPhoto> Photos { get; set; } = new();
     }

--- a/LikesAndSwipes/Views/User/GetUserPage.cshtml
+++ b/LikesAndSwipes/Views/User/GetUserPage.cshtml
@@ -8,6 +8,47 @@
         <h2>Обо мне:</h2>
     </div>
 
+    <form asp-controller="User" asp-action="UpdatePreferences" method="post" class="user-photo-upload-form">
+        @Html.AntiForgeryToken()
+        <p>Кого вы предпочитаете встретить:</p>
+
+        <div class="preference-group romantic-preference-group" id="romanticPreferenceGroup">
+            <h3>Romantic:</h3>
+            <label class="preference-option" id="romanticMenOption">
+                <input type="checkbox" name="romanticMen" value="true" checked="@Model.RomanticMen">
+                <span>Men</span>
+            </label>
+            <label class="preference-option" id="romanticWomenOption">
+                <input type="checkbox" name="romanticWomen" value="true" checked="@Model.RomanticWomen">
+                <span>Women</span>
+            </label>
+        </div>
+
+        <div class="preference-group friendship-preference-group">
+            <h3>Friendship:</h3>
+            <label class="preference-option">
+                <input type="checkbox" name="friendshipMen" value="true" checked="@Model.FriendshipMen">
+                <span>Men</span>
+            </label>
+            <label class="preference-option">
+                <input type="checkbox" name="friendshipWomen" value="true" checked="@Model.FriendshipWomen">
+                <span>Women</span>
+            </label>
+        </div>
+
+        <button type="submit" class="btn btn-primary" style="width: 220px; flex: none;">Сохранить предпочтения</button>
+    </form>
+
+    @if (TempData["PreferenceSuccess"] is string preferenceSuccessMessage)
+    {
+        <p class="user-photo-upload-success">@preferenceSuccessMessage</p>
+    }
+
+    @if (TempData["PreferenceError"] is string preferenceErrorMessage)
+    {
+        <p class="user-photo-upload-error">@preferenceErrorMessage</p>
+    }
+
     <form asp-controller="User" asp-action="UpdateBirthDay" method="post" class="user-photo-upload-form">
         @Html.AntiForgeryToken()
         <label for="birthDay">Дата рождения</label>


### PR DESCRIPTION
### Motivation
- Разрешить пользователю редактировать те же предпочтения `Romantic`/`Friendship` (для men/women), которые доступны при регистрации, прямо на странице профиля `/user`.

### Description
- Добавлены булевые свойства `RomanticMen`, `RomanticWomen`, `FriendshipMen`, `FriendshipWomen` в `UserProfilePhotosViewModel` для передачи текущих значений в представление.
- В `UserController` в `GET /user` заполняются новые поля из текущего пользователя, а также добавлен POST-обработчик `UpdatePreferences` (`user/preferences`), который сохраняет выбранные предпочтения, проверяет, что выбран хотя бы один флаг, и возвращает сообщения об ошибке/успехе через `TempData`.
- В `Views/User/GetUserPage.cshtml` добавлена форма редактирования предпочтений в разделе «Обо мне», повторяющая структуру выбора из страницы регистрации, и кнопка для сохранения.
- Изменения минимальны и не затрагивают схему БД — используются существующие поля модели `User`.

### Testing
- Попытка запустить автоматические тесты командой `dotnet test` не удалась, так как `dotnet` отсутствует в текущем окружении (`/bin/bash: line 1: dotnet: command not found`).
- Никаких других автоматизированных тестов в этом окружении не выполнялось.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec0c7151c4832d997778b91ae5e3db)